### PR TITLE
Modified  maximum allowed tag lenghth to 50 characters

### DIFF
--- a/app/models/classification.rb
+++ b/app/models/classification.rb
@@ -17,7 +17,7 @@ class Classification < ActiveRecord::Base
       c.class.in_my_region.exists?(cond)
     }
   validates_presence_of :name, :description
-  validates_length_of :name, :maximum => 30, :message => "must not exceed 30 characters"
+  validates_length_of :name, :maximum => 50, :message => "must not exceed 50 characters"
   validates_length_of :description, :maximum => 255, :message => "must not exceed 255 characters"
   validates_inclusion_of :syntax,
     :in => %w{ string integer boolean },


### PR DESCRIPTION
Sometimes it becomes necessary to have tags with larger names for proper identification of objects. 
Example,  A tag that contains names of the Openstack Provider and OpenStack Tenant . Currently
the maximum allowed charachter lenghth for tag is 30, This commit changes it to 50 characters.

Reference : http://talk.manageiq.org/t/cant-create-a-tag-with-more-than-30-characters/963
